### PR TITLE
publish user enter event to old room on room change

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -115,7 +115,10 @@ Session.prototype.enter_room = function(data) {
         this.currentRoom.emit('user_leave', { userId: this.id, roomId: this.currentRoom.id });
     }
 
+    // publish to old room
+    this.currentRoom.emit('user_enter', { userId: this.id, roomId: data.roomId });
 
+    //publish to new room
     this.currentRoom = this._server.getRoom(data.roomId);
     this.currentRoom.emit('user_enter', { userId: this.id, roomId: data.roomId });
 };


### PR DESCRIPTION
Currently the only way of knowing which room someone entered when they left your room is visually tracking which portal they were next to when the left. This make it hard to follow someone if there are a lot of portals close to each other, or if you're a bot with no eyes. 

If you publish a user_enter event into the old room, then it could make it easier to follow people through portals. (And in JanusVR there could even be a cool portal effect when someone leaves through the portal)

The clients should already be filtering on roomId  anyway, so there shouldn't be any added work on the client side if they're not using this feature.
