### PR TITLE
Updated versions required for janus-mysql-userlist and janus-mysql-auth.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "optimist": "^0.6.1",
     "simplesets": "^1.2.0",
     "split-ca": "^1.0.0",
-    "janus-mysql-userlist": "^0.0.2",
-    "janus-mysql-auth": "^0.0.1",
+    "janus-mysql-userlist": "^0.0.4",
+    "janus-mysql-auth": "^0.0.2",
     "janus-method-ping": "^0.0.3"
   }
 }


### PR DESCRIPTION
These plugins have been updated to use mysql connection pools.