### PR TITLE
Remove globals

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,17 +1,17 @@
 /* global log */
 var cluster = require('cluster');
 var redis = require('redis');
-global.config = require('./config.js');
+const config = require('./config.js');
 
-if (cluster.isMaster && global.config.multiprocess.enabled) {
-    var numCPUs  = global.config.multiproccess.processes;
+if (cluster.isMaster && config.multiprocess.enabled) {
+    var numCPUs = config.multiproccess.processes;
     console.log(`Starting ${numCPUs} workers`);
     console.log('========================');
     console.log('Janus VR Presence Server (clustered)');
     console.log('========================');
     console.log('See config.js for configuration');
     console.log('Startup date/time: ' + Date());
-    var redisClient = redis.createClient(global.config.redis);
+    var redisClient = redis.createClient(config.redis);
     redisClient.del('userlist:multi');
     redisClient.del('partylist:multi');
     for (var i = 0; i < numCPUs; i++) {
@@ -29,5 +29,5 @@ if (cluster.isMaster && global.config.multiprocess.enabled) {
 
 else {
     var Server = require("./src/Server.js");
-    (new Server()).start();
+    (new Server(config)).start();
 }

--- a/src/Plugins.js
+++ b/src/Plugins.js
@@ -1,5 +1,4 @@
 var args = require('optimist').argv;
-var config = require(args.config || '../config.js');
 var Session = require('./Session');
 
 function Plugins(server) {
@@ -13,7 +12,7 @@ function Plugins(server) {
 }
 
 Plugins.prototype.intervalLoad = function() {
-    var plugins = config.intervalPlugins;
+    var plugins = this._server.config.intervalPlugins;
 
     for(var p in plugins) {
         var file = plugins[p].plugin;
@@ -25,7 +24,7 @@ Plugins.prototype.intervalLoad = function() {
 }
 
 Plugins.prototype.methodLoad = function() {
-    var plugins = config.methodPlugins;
+    var plugins = this._server.config.methodPlugins;
 
     for(var method in plugins) {
         var file = plugins[method].plugin;
@@ -36,7 +35,7 @@ Plugins.prototype.methodLoad = function() {
 }
 
 Plugins.prototype.call = function(name, socket, command) {
-  var hook = config.hookPlugins[name];
+  var hook = this._server.config.hookPlugins[name];
 
   for(var k in hook.plugins) {
     var p = hook.plugins[k];

--- a/src/Room.js
+++ b/src/Room.js
@@ -5,7 +5,7 @@ function Room(id, server) {
     this.server = server; 
     this.id = id;
     this._sessions = new sets.Set();
-    if (global.config.multiprocess.enabled) {
+    if (server.config.multiprocess.enabled) {
         this.sub = server.redis.sub;
         this.pub = server.redis.pub;
         // subscribe from here, then have a global handler that hands off to room
@@ -36,7 +36,7 @@ Room.prototype.emitFromChannel = function(message) {
 
 Room.prototype.emit = function(event, data, relay) {
     relay = relay || true;
-    if (!global.config.multiprocess.enabled) relay = false;
+    if (!server.config.multiprocess.enabled) relay = false;
     var packet = JSON.stringify({method:event, data: data}) + "\r\n";
     // relay is a boolean switch to control whether the data
     // should be relayed to the redis channel for this room

--- a/src/Session.js
+++ b/src/Session.js
@@ -1,6 +1,5 @@
 var args = require('optimist').argv;
 var byline = require('byline');
-var config = require(args.config || '../config.js');
 var CRLF = "\r\n";
 const okayMessage = JSON.stringify({"method": "okay"}) + CRLF;
 var getMiddleware = require('./MethodMiddleware');


### PR DESCRIPTION
The use of globals for the config made it difficult to embed janus-server inside of other NodeJS apps.  This change removes the global config reference, and instead lets you pass a config object in when instantiating the Server class.